### PR TITLE
removed the type from the object sort

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -69,8 +69,7 @@
     },
     "sort": {
       "description": "Sort media queries.",
-      "link": "https://github.com/shoonia/css-mqpacker-webpack-plugin#sort",
-      "type": "boolean"
+      "link": "https://github.com/shoonia/css-mqpacker-webpack-plugin#sort"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Hello. Wanted to get sorting for "max-width" using "sort-css-media-queries" function but gave an invalid data type error. By removing the datatype specification for the "sort" object, I was able to pass a function, and the sort worked just fine. Maybe change this in your plugin.